### PR TITLE
Support full-screen cards

### DIFF
--- a/example/async_data/lib/main.dart
+++ b/example/async_data/lib/main.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-
 import 'package:flutter_tindercard/flutter_tindercard.dart';
 
 void main() => runApp(MyApp());
@@ -110,20 +109,17 @@ class _AsyncDataExampleHomePageState extends State<AsyncDataExampleHomePage>
           orientation: AmassOrientation.bottom,
           totalNum: imageList.length,
           stackNum: 4,
-          swipeEdge: 4.0,
           maxWidth: MediaQuery.of(context).size.width * 0.9,
           maxHeight: MediaQuery.of(context).size.width * 0.9,
-          minWidth: MediaQuery.of(context).size.width * 0.8,
-          minHeight: MediaQuery.of(context).size.width * 0.8,
           cardBuilder: (context, index) => Card(
             child: Image.asset('${imageList[index]}'),
           ),
           cardController: controller = CardController(),
-          swipeUpdateCallback: (DragUpdateDetails details, Alignment align) {
+          swipeUpdateCallback: (DragUpdateDetails details, Offset offset) {
             /// Get swiping card's alignment
-            if (align.x < 0) {
+            if (offset.dx < 0) {
               //Card is LEFT swiping
-            } else if (align.x > 0) {
+            } else if (offset.dx > 0) {
               //Card is RIGHT swiping
             }
           },

--- a/example/example/lib/main.dart
+++ b/example/example/lib/main.dart
@@ -47,20 +47,17 @@ class _ExampleHomePageState extends State<ExampleHomePage>
             orientation: AmassOrientation.bottom,
             totalNum: welcomeImages.length,
             stackNum: 3,
-            swipeEdge: 4.0,
             maxWidth: MediaQuery.of(context).size.width * 0.9,
             maxHeight: MediaQuery.of(context).size.width * 0.9,
-            minWidth: MediaQuery.of(context).size.width * 0.8,
-            minHeight: MediaQuery.of(context).size.width * 0.8,
             cardBuilder: (context, index) => Card(
               child: Image.asset('${welcomeImages[index]}'),
             ),
             cardController: controller = CardController(),
-            swipeUpdateCallback: (DragUpdateDetails details, Alignment align) {
+            swipeUpdateCallback: (DragUpdateDetails details, Offset offset) {
               /// Get swiping card's alignment
-              if (align.x < 0) {
+              if (offset.dx < 0) {
                 //Card is LEFT swiping
-              } else if (align.x > 0) {
+              } else if (offset.dx > 0) {
                 //Card is RIGHT swiping
               }
             },

--- a/lib/flutter_tindercard.dart
+++ b/lib/flutter_tindercard.dart
@@ -68,7 +68,7 @@ class TinderSwapCard extends StatefulWidget {
   })  : assert(stackNum > 1),
         assert(swipeEdge > 0),
         assert(swipeEdgeVertical > 0),
-        assert(maxWidth > minWidth && maxHeight > minHeight),
+        assert(maxWidth >= minWidth && maxHeight >= minHeight),
         _cardBuilder = cardBuilder,
         _totalNum = totalNum,
         _stackNum = stackNum,
@@ -81,14 +81,14 @@ class TinderSwapCard extends StatefulWidget {
     final widthGap = maxWidth - minWidth;
     final heightGap = maxHeight - minHeight;
 
-    for (var i = 0; i < _stackNum; i++) {
+    int i = _stackNum;
+    while (i-- != 0) {
       _cardSizes.add(
-        Size(minWidth + (widthGap / _stackNum) * i,
-            minHeight + (heightGap / _stackNum) * i),
+        Size(maxWidth - (widthGap / _stackNum) * i, maxHeight - (heightGap / _stackNum) * i),
       );
 
       switch (orientation) {
-        case AmassOrientation.bottom:
+        case AmassOrientation.top:
           _cardAligns.add(
             Alignment(
               0.0,
@@ -96,7 +96,7 @@ class TinderSwapCard extends StatefulWidget {
             ),
           );
           break;
-        case AmassOrientation.top:
+        case AmassOrientation.bottom:
           _cardAligns.add(
             Alignment(
               0.0,


### PR DESCRIPTION
The main purpose of this PR is to allow cards to be full-screen without the odd behaviour mentioned in #55.

In order to achieve this I've had to make a number of changes:

- `Transform` is used to translate and scale the card instead of `Align` and `SizedBox`
- Switching from `SizedBox` means that text on the card is resized instead of moved to different lines when the card size animates.
- Cards behind the front card are scaled in perspective, so you can have unlimited cards in your stack without cards at the back suddenly becoming larger
- Instead of specifying a minimum height/width, you can specify a scaling factor.
- card[0] is the front card - it removes a lot of complexity from the code
- the rotation angle depends on whether you started dragging the top or bottom half of the card. The card stays pinned under your finger and the far end drags behind.